### PR TITLE
Audio Multiply (FM synthesis node)

### DIFF
--- a/node/vuo.audio/vuo.audio.multiply.c
+++ b/node/vuo.audio/vuo.audio.multiply.c
@@ -1,0 +1,38 @@
+#include "node.h"
+
+VuoModuleMetadata({
+                     "title" : "Multiply 2 Audio Channels",
+                     "keywords" : [ "sound", "music", "merge", "combine", "FM Synthesis" ],
+                     "version" : "0.0.1",
+                     "node": {
+                       //  "exampleCompositions" : [ "PanAudio.vuo" ],
+                     }
+                 });
+
+void nodeEvent
+(
+        VuoInputData(VuoList_VuoAudioSamples) samples,
+        VuoOutputData(VuoAudioSamples) mixedSamples
+)
+{
+  unsigned int channelCount = VuoListGetCount_VuoAudioSamples(samples);
+
+  *mixedSamples = VuoAudioSamples_alloc(VuoAudioSamples_bufferSize);
+
+  for(unsigned int n = 0; n < (*mixedSamples).sampleCount; n++)
+  
+  (*mixedSamples).samples[n] = 0.;
+
+  for(unsigned int i = 0; i < channelCount; i++)
+  {
+    VuoAudioSamples as = VuoListGetValue_VuoAudioSamples(samples, i+1);
+
+  if(i == 0)
+    {
+      for(unsigned int n = 0; n < as.sampleCount; n++)
+      (*mixedSamples).samples[n] = as.samples[n];
+    }
+    for(unsigned int n = 0; n < as.sampleCount; n++)
+    (*mixedSamples).samples[n] *= as.samples[n];
+  }
+}

--- a/node/vuo.audio/vuo.audio.multiply.c
+++ b/node/vuo.audio/vuo.audio.multiply.c
@@ -1,3 +1,12 @@
+/**
+ * @file
+ * vuo.audio.mix node implementation.
+ *
+ * @copyright Copyright © 2012–2014 Kosada Incorporated.
+ * This code may be modified and distributed under the terms of the MIT License.
+ * For more information, see http://vuo.org/license.
+ */
+
 #include "node.h"
 
 VuoModuleMetadata({

--- a/node/vuo.audio/vuo.audio.multiply.c
+++ b/node/vuo.audio/vuo.audio.multiply.c
@@ -14,7 +14,7 @@ VuoModuleMetadata({
                      "keywords" : [ "sound", "music", "merge", "combine", "FM Synthesis" ],
                      "version" : "0.0.1",
                      "node": {
-                       //  "exampleCompositions" : [ "PanAudio.vuo" ],
+                        "exampleCompositions" : [ ],
                      }
                  });
 

--- a/node/vuo.audio/vuo.audio.multiply.c
+++ b/node/vuo.audio/vuo.audio.multiply.c
@@ -11,10 +11,10 @@
 
 VuoModuleMetadata({
                      "title" : "Multiply 2 Audio Channels",
-                     "keywords" : [ "sound", "music", "merge", "combine", "FM Synthesis" ],
+                     "keywords" : [ "sound", "music", "merge", "combine", "FM Synthesis", "multiply" ],
                      "version" : "0.0.1",
                      "node": {
-                        "exampleCompositions" : [ ],
+                        "exampleCompositions" : [ ]
                      }
                  });
 

--- a/node/vuo.audio/vuo.audio.pro
+++ b/node/vuo.audio/vuo.audio.pro
@@ -18,6 +18,7 @@ NODE_SOURCES += \
 	vuo.audio.make.output.id.c \
 	vuo.audio.make.output.name.c \
 	vuo.audio.mix.c \
+	vuo.audio.multiply.c \
 	vuo.audio.receive.c \
 	vuo.audio.send.c \
 	vuo.audio.split.frequency.cc \


### PR DESCRIPTION
A new node for FM Synthesis - accepts any number of inputs, and multiplies them together. 
Node is stateless.
