### PR TITLE
Improve keywords

### DIFF
--- a/node/vuo.list/descriptions/vuo.list.enqueue.md
+++ b/node/vuo.list/descriptions/vuo.list.enqueue.md
@@ -5,6 +5,9 @@ This node stores the most recently added items in a list. The list is "first in,
    - `Add Item` — When this port receives an event, the given item is added to the list. If this makes the list exceed `Max Item Count`, the item added longest ago is removed from the list.
    - `Max Item Count` — The maximum number of items in the list. If this is 0, the node always outputs an empty list. If this is `Auto`, the list will be unlimited.
    - `Clear List` — When this port receives an event, all items are removed from the list.
+   - `Discard When Full` -
+      - Oldest - Discards items in the list from oldest to newest when list is full (default).
+      - Newest - Prevents adding additional items when list is full.
    - `List` — The list of recent items, in order from oldest to newest.
 
 If an event hits both `Add Item` and `Clear List`, then the list is cleared before the item is added.

--- a/node/vuo.list/descriptions/vuo.list.enqueue.md
+++ b/node/vuo.list/descriptions/vuo.list.enqueue.md
@@ -11,3 +11,5 @@ This node stores the most recently added items in a list. The list is "first in,
    - `List` — The list of recent items, in order from oldest to newest.
 
 If an event hits both `Add Item` and `Clear List`, then the list is cleared before the item is added.
+
+Thanks to [Martinus Magneson](https://vuo.org/user/3272) for the idea of the Discard when Full port.

--- a/node/vuo.list/descriptions/vuo.list.enqueue.md
+++ b/node/vuo.list/descriptions/vuo.list.enqueue.md
@@ -2,8 +2,8 @@ Adds an item to a list, discarding the oldest item from the list if needed.
 
 This node stores the most recently added items in a list. The list is "first in, first out" — as new items are added, the oldest items are removed to make room.
 
-   - `Max Item Count` — The maximum number of items in the list. If this is 0, the node always outputs an empty list. If this is `Auto`, the list will be unlimited.
    - `Add Item` — When this port receives an event, the given item is added to the list. If this makes the list exceed `Max Item Count`, the item added longest ago is removed from the list.
+   - `Max Item Count` — The maximum number of items in the list. If this is 0, the node always outputs an empty list. If this is `Auto`, the list will be unlimited.
    - `Clear List` — When this port receives an event, all items are removed from the list.
    - `List` — The list of recent items, in order from oldest to newest.
 

--- a/node/vuo.list/vuo.list.enqueue.c
+++ b/node/vuo.list/vuo.list.enqueue.c
@@ -36,6 +36,10 @@ void nodeInstanceEvent
 		VuoInputData(VuoGenericType1) addItem,
 		VuoInputEvent({"eventBlocking":"none","data":"addItem"}) addItemEvent,
 		VuoInputEvent({"eventBlocking":"none"}) clearList,
+		VuoInputData(VuoInteger, {"menuItems":[
+			{"value":0, "name": "Oldest"},
+			{"value":1, "name": "Newest"}
+		], "default": 0}) discardWhenFull,
 		VuoOutputData(VuoList_VuoGenericType1) list
 )
 {
@@ -47,8 +51,11 @@ void nodeInstanceEvent
 
 	unsigned long clampedMaxItemCount = MAX(0, maxItemCount);
 	unsigned long itemCount = VuoListGetCount_VuoGenericType1(*listInstanceData);
-	for ( ; itemCount > clampedMaxItemCount; --itemCount)
-		VuoListRemoveFirstValue_VuoGenericType1(*listInstanceData);
+		for ( ; itemCount > clampedMaxItemCount; --itemCount)
+			if(discardWhenFull)
+				VuoListRemoveLastValue_VuoGenericType1(*listInstanceData);
+			else
+				VuoListRemoveFirstValue_VuoGenericType1(*listInstanceData);
 
 	*list = VuoListCreate_VuoGenericType1();
 	for (unsigned long i = 1; i <= itemCount; ++i)

--- a/node/vuo.list/vuo.list.enqueue.c
+++ b/node/vuo.list/vuo.list.enqueue.c
@@ -31,10 +31,10 @@ VuoList_VuoGenericType1 nodeInstanceInit
 void nodeInstanceEvent
 (
 		VuoInstanceData(VuoList_VuoGenericType1) listInstanceData,
-		VuoInputData(VuoInteger, { "default":10, "suggestedMin":0, "auto":infinity }) maxItemCount,
-		VuoInputEvent({"eventBlocking":"wall","data":"maxItemCount"}) maxItemCountEvent,
 		VuoInputData(VuoGenericType1) addItem,
 		VuoInputEvent({"eventBlocking":"none","data":"addItem"}) addItemEvent,
+		VuoInputData(VuoInteger, { "default":10, "suggestedMin":0, "auto":infinity }) maxItemCount,
+		VuoInputEvent({"eventBlocking":"wall","data":"maxItemCount"}) maxItemCountEvent,
 		VuoInputEvent({"eventBlocking":"none"}) clearList,
 		VuoInputData(VuoInteger, {"menuItems":[
 			{"value":0, "name": "Oldest"},

--- a/node/vuo.list/vuo.list.get.multiple.c
+++ b/node/vuo.list/vuo.list.get.multiple.c
@@ -11,7 +11,7 @@
 
 VuoModuleMetadata({
 					 "title" : "Get Items from List",
-					 "keywords" : [ "pick", "select", "choose", "element", "member", "index", "indices" ],
+					 "keywords" : [ "pick", "select", "choose", "element", "member", "index", "indices", "reorder", "rearrange", "shuffle", "combination" ],
 					 "version" : "1.0.1",
 					 "node": {
 						  "exampleCompositions" : [ "SelectLayerFromList.vuo" ]

--- a/node/vuo.list/vuo.list.shuffle.c
+++ b/node/vuo.list/vuo.list.shuffle.c
@@ -11,7 +11,7 @@
 
 VuoModuleMetadata({
 					  "title" : "Shuffle List",
-					  "keywords" : [ "random", "pseudorandom", "PRNG", "RNG", "reorder", "sort", "permutation" ],
+					  "keywords" : [ "random", "pseudorandom", "PRNG", "RNG", "reorder", "sort", "permutation", "rearrange", "jumble" ],
 					  "version" : "1.0.0",
 					  "node" : {
 						  "exampleCompositions" : [ "ShuffleLetters.vuo" ]


### PR DESCRIPTION
Added the following keywords to make `Get Items from List` easier to find if you want to reorder a list:  
_reorder, rearrange, shuffle, combination_ to **vuo.list.get.multiple.c** and _rearrange, jumble_ to **vuo.list.shuffle.c**